### PR TITLE
Create bower dependency list with bootstrap and jquery.

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,1 @@
+{ "directory": "static/bower/" }

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ target/
 
 #Ipython Notebook
 .ipynb_checkpoints
+
+# Bower built static files
+static/bower/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+static: bower
+bower:
+	bower install

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,18 @@
+{
+  "name": "junaid",
+  "homepage": "https://github.com/Team4761/Junaid",
+  "description": "A scouting platform built with Flask (Python).",
+  "license": "MIT",
+  "private": true,
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ],
+  "dependencies": {
+    "jquery": "^2.2.3",
+    "bootstrap": "^3.3.6"
+  }
+}


### PR DESCRIPTION
This works on issue #6.

I also created a Makefile along with this change. It should be noted instead of
installing things with bower through Makefile targets we should be careful to
add them to bower.json as dependencies. That way we only need to run bower
install to get the static css and js components. This saves time and work.

I've left out chartist because we haven't gotten to graphing and that's a
distraction from core elements right now.
